### PR TITLE
Clarify repository AGENTS guidance for builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Instructions
+
+The guidelines below apply to the entire repository.
+
+- Follow the existing coding style of the surrounding files.
+- Keep documentation in sync with code updates when appropriate.
+- Use clear, descriptive commit messages that summarize the change set.
+- Before invoking any CMake build or test, make sure the source tree is reachable
+  at `<parent>/usml` (rename the checkout to `usml` or create a `usml`
+  symlink pointing to this directory) so includes such as
+  `<usml/ublas/randgen.h>` resolve correctly.
+- Run the CMake-based builds or unit tests that are relevant to your changes
+  and report their status in the final summary.


### PR DESCRIPTION
## Summary
- expand the top-level `AGENTS.md` to explain that guidelines apply repo-wide
- document the requirement to expose the checkout as `usml` before running CMake builds or tests
- clarify expectations for documentation updates, commit messages, and reporting test status

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d4b5a163fc83288b70db71294e80fe